### PR TITLE
Update BYOC lab prerequisites to link to solutions folder

### DIFF
--- a/labs/byoc-powerapps/byoc-powerapps.md
+++ b/labs/byoc-powerapps/byoc-powerapps.md
@@ -62,7 +62,7 @@ The BYOC feature empowers development teams to **reuse existing code** or **crea
 
 # 6. Prerequisites
 
-Import Northwind Traders version 1.0.0.11 or later to the environment and seed with data using the Northwind Sample Data App. [See Solutions folder for the solution and full instructions](../../../solutions/README.md)
+Import Northwind Traders version 1.0.0.11 or later to the environment and seed with data using the Northwind Sample Data App. [See Solutions folder for the solution and full instructions](../../solutions/)
 
 [Node.js Long-term support (LTS) version](https://nodejs.org/)
 

--- a/labs/byoc-powerapps/byoc-powerapps.md
+++ b/labs/byoc-powerapps/byoc-powerapps.md
@@ -62,9 +62,9 @@ The BYOC feature empowers development teams to **reuse existing code** or **crea
 
 # 6. Prerequisites
 
-Import Northwind Traders version 1.0.0.11 or later to the environment and seed with data. [Solutions](https://github.com/microsoft/apps-agents-workshop/tree/main/solutions)
+Import Northwind Traders version 1.0.0.11 or later to the environment and seed with data using the Northwind Sample Data App. [See Solutions folder for the solution and full instructions](../../../solutions/README.md)
 
-[Node.js Long term support (LTS) version](https://nodejs.org/) 
+[Node.js Long-term support (LTS) version](https://nodejs.org/)
 
 [Power Platform CLI](https://learn.microsoft.com/power-platform/developer/cli/introduction?tabs=windows)
 


### PR DESCRIPTION
Updates the prerequisites section in the BYOC Power Apps lab:

- Links "See Solutions folder" to the relative `../../solutions/` path so users can see both the ZIP file and the README
- Minor wording fix: "Long term" → "Long-term" in the Node.js prerequisite